### PR TITLE
거의_최단_경로_5719

### DIFF
--- a/5719.cpp
+++ b/5719.cpp
@@ -1,0 +1,101 @@
+#include <iostream>
+#include <queue>
+#include <vector>
+#include <cstring>
+using namespace std;
+
+const int MAX = 501;
+const int INF = 987654321;
+
+int n, m, s, d, u, v, p, dist[MAX];
+vector<pair<int, int>> arr[MAX];
+vector<int> prevArr[MAX];
+
+bool checked[MAX][MAX];
+
+void dijkstra(int start) {
+    priority_queue<pair<int, int>> pq;
+
+    pq.push({ 0, start });
+    dist[start] = 0;
+
+    while (!pq.empty()) {
+        int curDist = -pq.top().first;
+        int cur = pq.top().second;
+        pq.pop();
+
+        if (dist[cur] > curDist)
+            continue;
+
+        for (int i = 0; i < arr[cur].size(); i++) {
+            if (!checked[cur][arr[cur][i].second])
+                continue;
+
+            int nextDist = curDist + arr[cur][i].first;
+            int next = arr[cur][i].second;
+
+            if (dist[next] > nextDist) {
+                prevArr[next].clear();
+                prevArr[next].push_back(cur);
+                dist[next] = nextDist;
+                pq.push({ -nextDist, next });
+            }
+            else if (dist[next] == nextDist)
+                prevArr[next].push_back(cur);
+        }
+    }
+}
+
+void removeEdge(int ed) {
+    for (int i = 0; i < prevArr[ed].size(); i++) {
+        int cur = prevArr[ed][i];
+
+        if (!checked[cur][ed])
+            continue;
+
+        removeEdge(cur);
+
+        checked[cur][ed] = false;
+    }
+}
+
+int main() {
+    ios::sync_with_stdio(0);
+    cin.tie(0);
+
+    while (1) {
+        cin >> n >> m;
+        if (n == 0 && m == 0)
+            break;
+
+        memset(checked, true, sizeof(checked));
+
+        for (int i = 0; i < n; i++) {
+            arr[i].clear();
+            prevArr[i].clear();
+            dist[i] = INF;
+        }
+
+        cin >> s >> d;
+        for (int i = 0; i < m; i++) {
+            cin >> u >> v >> p;
+
+            arr[u].push_back({ p, v });
+        }
+
+        dijkstra(s);
+        removeEdge(d);
+
+        for (int i = 0; i < n; i++)
+            dist[i] = INF;
+
+        dijkstra(s);
+
+        if (dist[d] == INF)
+            cout << -1 << '\n';
+        else
+            cout << dist[d] << '\n';
+    }
+
+    return 0;
+}


### PR DESCRIPTION
[문제 참조](https://www.acmicpc.net/problem/5719)

# 다익스트라 문제
## 해결법
- 거의 최단 경로는 최단 경로에 포함되지 않는 도로로만 이루어진 경로
  - 고로, 다익스트라 알고리즘을 이용해서 기존 최단 경로로 지정된 간선을 삭제해야함
- 첫 번째 로직에서 삭제된 간선을 제외하고 다시 다익스트라 알고리즘을 이용하여 최단 경로 거리를 구함
